### PR TITLE
Use property to alias ForeignKey fields instead of Pydantic alias

### DIFF
--- a/docs/docs/guides/response/config-pydantic.md
+++ b/docs/docs/guides/response/config-pydantic.md
@@ -30,7 +30,7 @@ class CamelModelSchema(Schema):
 ```
 
 !!! note
-    When overriding the schema's `Config`, it is necessary to inherit from the base `Config` class. 
+    When overriding the schema's `Config`, it is necessary to inherit from the base `Schema.Config` class. 
 
 To alias `ModelSchema`'s field names, you'll also need to set `populate_by_name` on the `Schema` config and 
 enable `by_alias` in all endpoints using the model.

--- a/docs/docs/guides/response/config-pydantic.md
+++ b/docs/docs/guides/response/config-pydantic.md
@@ -9,17 +9,16 @@ There are many customizations available for a **Django Ninja `Schema`**, via the
     when using Django models, as Pydantic's model class is called Model by default, and conflicts with
     Django's Model class.
 
-## Example Camel Case mode
+## Automatic Camel Case Aliases
 
-One interesting `Config` attribute is [`alias_generator`](https://pydantic-docs.helpmanual.io/usage/model_config/#alias-generator).
+One useful `Config` attribute is [`alias_generator`](https://pydantic-docs.helpmanual.io/usage/model_config/#alias-generator).
+We can use it to automatically generate aliases for field names with a given function. This is mostly commonly used to create
+an API that uses camelCase for its property names.
 Using Pydantic's example in **Django Ninja** can look something like:
 
-```python hl_lines="12 13"
+```python hl_lines="9 10"
 from ninja import Schema
-
-
-def to_camel(string: str) -> str:
-    return ''.join(word.capitalize() for word in string.split('_'))
+from pydantic.alias_generators import to_camel
 
 
 class CamelModelSchema(Schema):
@@ -33,15 +32,18 @@ class CamelModelSchema(Schema):
 !!! note
     When overriding the schema's `Config`, it is necessary to inherit from the base `Config` class. 
 
-Keep in mind that when you want modify output for field names (like camel case) - you need to set as well  `populate_by_name` and `by_alias`
+To alias `ModelSchema`'s field names, you'll also need to set `populate_by_name` on the `Schema` config and 
+enable `by_alias` in all endpoints using the model.
 
-```python hl_lines="6 9"
+```python hl_lines="4 11"
 class UserSchema(ModelSchema):
-    class Config:
-        model = User
-        model_fields = ["id", "email"]
+    class Config(Schema.Config):
         alias_generator = to_camel
         populate_by_name = True  # !!!!!! <--------
+        
+    class Meta:
+        model = User
+        model_fields = ["id", "email", "created_date"]
 
 
 @api.get("/users", response=list[UserSchema], by_alias=True) # !!!!!! <-------- by_alias
@@ -55,13 +57,15 @@ results:
 ```JSON
 [
   {
-    "Id": 1,
-    "Email": "tim@apple.com"
+    "id": 1,
+    "email": "tim@apple.com",
+    "createdDate": "2011-08-24"
   },
   {
-    "Id": 2,
-    "Email": "sarah@smith.com"
-  }
+    "id": 2,
+    "email": "sarah@smith.com",
+    "createdDate": "2012-03-06"
+  },
   ...
 ]
 

--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -97,10 +97,11 @@ class SchemaFactory:
         self.schemas[key] = schema
         self.schema_names.add(name)
 
-        for fld in model_fields_list:
-            if fld.is_relation:
-                field_name, prop = get_field_property_accessors(fld)
-                setattr(schema, field_name, prop)
+        if depth == 0:
+            for fld in model_fields_list:
+                if fld.is_relation:
+                    field_name, prop = get_field_property_accessors(fld)
+                    setattr(schema, field_name, prop)
 
         return schema
 

--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -62,6 +62,7 @@ class SchemaFactory:
 
         definitions = {}
         for fld in model_fields_list:
+            # types: ignore
             field_name, python_type, field_info = get_schema_field(
                 fld,
                 depth=depth,

--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -6,7 +6,7 @@ from django.db.models import ManyToManyRel, ManyToOneRel, Model
 from pydantic import create_model as create_pydantic_model
 
 from ninja.errors import ConfigError
-from ninja.orm.fields import get_schema_field, get_field_property_accessors
+from ninja.orm.fields import get_field_property_accessors, get_schema_field
 from ninja.schema import Schema
 
 # MAYBE:

--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -98,11 +98,13 @@ class SchemaFactory:
         self.schemas[key] = schema
         self.schema_names.add(name)
 
+        # Create aliases for any foreign keys
         if depth == 0:
             for fld in model_fields_list:
-                if fld.is_relation:
-                    field_name, prop = get_field_property_accessors(fld)
-                    setattr(schema, field_name, prop)
+                # Do not create the alias if the user manually defined a field with the same name
+                if fld.is_relation and fld.name not in schema.model_fields:
+                    prop = get_field_property_accessors(fld)
+                    setattr(schema, fld.name, prop)
 
         return schema
 

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -115,7 +115,7 @@ def create_m2m_link_type(type_: Type[TModel]) -> Type[TModel]:
 
 @no_type_check
 def get_schema_field(
-    field: DjangoField, *, depth: int = 0, optional: bool = False
+        field: DjangoField, *, depth: int = 0, optional: bool = False
 ) -> Tuple:
     "Returns pydantic field from django's model field"
     name = field.name
@@ -226,6 +226,11 @@ def get_related_field_schema(field: DjangoField, *, depth: int) -> Tuple[OpenAPI
 def get_field_property_accessors(field: DjangoField):
     attribute_name = getattr(field, "get_attname", None) and field.get_attname()
     property_name = field.name
-    fget = lambda self: getattr(self, attribute_name)
-    fset = lambda self, value: setattr(self, attribute_name, value)
-    return property_name, property(fget, fset)
+
+    def getter(self):
+        getattr(self, attribute_name)
+
+    def setter(self, value):
+        setattr(self, attribute_name, value)
+
+    return property_name, property(getter, setter)

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -235,11 +235,10 @@ def get_related_field_schema(
     )
 
 
-def get_field_property_accessors(field: DjangoField) -> Tuple[str, property]:
+def get_field_property_accessors(field: DjangoField) -> property:
     attribute_name = cast(
         str, getattr(field, "get_attname", None) and field.get_attname()
     )
-    property_name: str = field.name
 
     def getter(self: BaseModel) -> Any:
         return getattr(self, attribute_name)
@@ -247,4 +246,4 @@ def get_field_property_accessors(field: DjangoField) -> Tuple[str, property]:
     def setter(self: BaseModel, value: Any) -> None:
         setattr(self, attribute_name, value)
 
-    return property_name, property(getter, setter)
+    return property(getter, setter)

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -130,7 +130,8 @@ def get_schema_field(
 
     if field.is_relation:
         if depth > 0:
-            return name, *get_related_field_schema(field, depth=depth)
+            python_type, field_info = get_related_field_schema(field, depth=depth)
+            return name, python_type, field_info
 
         internal_type = field.related_model._meta.pk.get_internal_type()
 
@@ -200,7 +201,7 @@ def get_schema_field(
 
 
 @no_type_check
-def get_related_field_schema(field: DjangoField, *, depth: int) -> Tuple[OpenAPISchema]:
+def get_related_field_schema(field: DjangoField, *, depth: int) -> Tuple[OpenAPISchema, FieldInfo]:
     from ninja.orm import create_schema
 
     model = field.related_model

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -55,7 +55,7 @@ def test_alias_foreignkey_schema():
         id = models.AutoField(primary_key=True)
         name = models.CharField(max_length=100)
         author = models.ForeignKey(Author, on_delete=models.CASCADE)
-        published_date = models.DateField(default=datetime.date.today())
+        published_date = models.DateField(default=datetime.date(2024, 1, 1))
 
         class Meta:
             app_label = "tests"
@@ -73,7 +73,7 @@ def test_alias_foreignkey_schema():
             "id": {"anyOf": [{"type": "integer"}, {"type": "null"}], "title": "Id"},
             "name": {"maxLength": 100, "title": "Name", "type": "string"},
             "publishedDate": {
-                "default": "2024-03-22",
+                "default": "2024-01-01",
                 "format": "date",
                 "title": "Published Date",
                 "type": "string",

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -103,9 +103,7 @@ def test_alias_foreignkey_property():
             app_label = "tests"
 
     class BookSchema(ModelSchema):
-        class Config(Schema.Config):
-            alias_generator = to_camel
-            populate_by_name = True
+        model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
         class Meta:
             model = Book

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -1,4 +1,10 @@
-from ninja import Field, NinjaAPI, Schema
+import datetime
+
+from django.db import models
+from pydantic import ConfigDict
+from pydantic.alias_generators import to_camel
+
+from ninja import Field, ModelSchema, NinjaAPI, Schema
 
 
 class SchemaWithAlias(Schema):
@@ -35,3 +41,77 @@ def test_alias():
 # @api.post("/path", response=SchemaWithAlias)
 # def alias_operation(request, payload: SchemaWithAlias):
 #     return {"bar": payload.foo}
+
+
+def test_alias_foreignkey_schema():
+    class Author(models.Model):
+        id = models.AutoField(primary_key=True)
+        name = models.CharField(max_length=50)
+
+        class Meta:
+            app_label = "tests"
+
+    class Book(models.Model):
+        id = models.AutoField(primary_key=True)
+        name = models.CharField(max_length=100)
+        author = models.ForeignKey(Author, on_delete=models.CASCADE)
+        published_date = models.DateField(default=datetime.date.today())
+
+        class Meta:
+            app_label = "tests"
+
+    class BookSchema(ModelSchema):
+        model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+        class Meta:
+            model = Book
+            fields = "__all__"
+
+    assert BookSchema.json_schema() == {
+        "properties": {
+            "authorId": {"title": "Author", "type": "integer"},
+            "id": {"anyOf": [{"type": "integer"}, {"type": "null"}], "title": "Id"},
+            "name": {"maxLength": 100, "title": "Name", "type": "string"},
+            "publishedDate": {
+                "default": "2024-03-22",
+                "format": "date",
+                "title": "Published Date",
+                "type": "string",
+            },
+        },
+        "required": ["name", "authorId"],
+        "title": "BookSchema",
+        "type": "object",
+    }
+
+
+def test_alias_foreignkey_property():
+    class Author(models.Model):
+        id = models.AutoField(primary_key=True)
+        name = models.CharField(max_length=50)
+
+        class Meta:
+            app_label = "tests"
+
+    class Book(models.Model):
+        id = models.AutoField(primary_key=True)
+        name = models.CharField(max_length=100)
+        author = models.ForeignKey(Author, on_delete=models.CASCADE)
+        published_date = models.DateField(default=datetime.date.today())
+
+        class Meta:
+            app_label = "tests"
+
+    class BookSchema(ModelSchema):
+        model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+        class Meta:
+            model = Book
+            fields = "__all__"
+
+    author_test = Author(name="J. R. R. Tolkien", id=1)
+    model_test = Book(author=author_test, name="The Hobbit", id=1)
+    schema_test = BookSchema.from_orm(model_test)
+
+    schema_test.author = 2
+    assert schema_test.author == 2

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -103,7 +103,9 @@ def test_alias_foreignkey_property():
             app_label = "tests"
 
     class BookSchema(ModelSchema):
-        model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+        class Config(Schema.Config):
+            alias_generator = to_camel
+            populate_by_name = True
 
         class Meta:
             model = Book
@@ -115,3 +117,4 @@ def test_alias_foreignkey_property():
 
     schema_test.author = 2
     assert schema_test.author == 2
+    assert schema_test.author_id == 2


### PR DESCRIPTION
Currently for ModelSchema, Ninja uses Pydantic aliases to alias between a ForeignKey field's property name as defined by the user, and the attribute name which holds the ID referenced by the foreign key (`author` vs `author_id`). However, this prevents users from using Pydantic's `alias_generator` with ForeignKey field names.

This PR removes the alias and then changes the property name on the Pydantic model to match the attribute name on the Django model (`author_id`), which should allow for data dumped out with `my_schema.model_dump()` to still correctly match up to Django fields as it does now. It then adds `property` fields to alias between the attribute name and the property name, so any accesses on the model, like `my_schema.author`, will get aliased to the real property name, `my_schema.author_id`.
