### PR TITLE
Fix tests on Pydantic 2.11 and sync Ruff version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,9 @@ repos:
         additional_dependencies: ["django-stubs", "pydantic"]
         exclude: (tests|docs)/
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.2
+    rev: v0.5.7
     hooks:
       - id: ruff-format
+        args: [--preview]
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/tests/test_orm_schemas.py
+++ b/tests/test_orm_schemas.py
@@ -5,7 +5,7 @@ import pytest
 from django.contrib.postgres import fields as ps_fields
 from django.db import models
 from django.db.models import Manager
-from util import pydantic_ref_fix
+from util import pydantic_arbitrary_dict_fix, pydantic_ref_fix
 
 from ninja.errors import ConfigError
 from ninja.orm import create_schema, register_field
@@ -154,7 +154,10 @@ def test_all_fields():
                 "title": "Ciemailfield",
             },
             "citextfield": {"type": "string", "title": "Citextfield"},
-            "hstorefield": {"type": "object", "title": "Hstorefield"},
+            "hstorefield": pydantic_arbitrary_dict_fix({
+                "type": "object",
+                "title": "Hstorefield",
+            }),
         },
         "required": [
             "bigintegerfield",

--- a/tests/util.py
+++ b/tests/util.py
@@ -11,3 +11,18 @@ def pydantic_ref_fix(data: dict):
     if "$ref" in data:
         result["allOf"] = [{"$ref": result.pop("$ref")}]
     return result
+
+
+def pydantic_arbitrary_dict_fix(data: dict):
+    """
+    In Pydantic 2.11, arbitrary dictionaries now contain "additionalProperties": True in the schema
+    https://github.com/pydantic/pydantic/pull/11392
+
+    :param data: A pre-Pydantic 2.11 arbitrary dictionary schema
+    """
+    v = tuple(map(int, pydantic.version.version_short().split(".")))
+    if v < (2, 11):
+        return data
+
+    data["additionalProperties"] = True
+    return data


### PR DESCRIPTION
We really should be locking down Pydantic versions...

Also need to sync Ruff version in pre-commit here in the same PR because neither change can get through the CI without the other

Also the CI uses --preview Ruff but pre-commit wasn't