### PR TITLE
Add CharField.choices Support

### DIFF
--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -175,6 +175,26 @@ def get_schema_field(
             ]
             raise ConfigError("\n".join(msg)) from e
 
+        if hasattr(field, "choices") and field.choices:
+            choices = [choice[0] for choice in field.choices]
+            if null or optional:
+                default = None
+                nullable = True
+                python_type = Union[python_type, None]
+
+            field_info = FieldInfo(
+                default=default,
+                alias=alias,
+                validation_alias=alias,
+                serialization_alias=alias,
+                default_factory=default_factory,
+                title=title,
+                description=description,
+                max_length=max_length,
+                json_schema_extra={"enum": choices},
+            )
+            return name, python_type, field_info
+
         if null or optional:
             default = None
             nullable = True


### PR DESCRIPTION
Attempt at addressing the lack of support for CharField Fields with `choices` attributes so that pydantic validation ensures data is valid. As reported on django-ninja here: https://github.com/vitalik/django-ninja/issues/1078.