### PR TITLE
ModelSchema: Add support for choices

### DIFF
--- a/docs/docs/guides/response/django-pydantic.md
+++ b/docs/docs/guides/response/django-pydantic.md
@@ -177,14 +177,15 @@ in this example the `payload` argument will be a type of `dict` only fields that
 
 ### Choices and Enums
 
+If you define a Model field with `.choices`, `ModelSchema` will automatically carry that into your schema.
+
+However, if you are reusing the enum in multiple places, or if you are working with auto-generated OpenAPI clients, 
+it may be useful to create enum objects that are reusable between schemas and fields. 
+Shinobi can directly carry over a `TextChoices` or `IntegerChoices` enum by adding the `ChoicesMixin` to it.
+
 !!! info
-    Requires Django 5.0+ and Python 3.11+
+    `ChoicesMixin` requires Django 5.0+ and Python 3.11+
 
-By default, ModelSchema, will ignore `choices` on a Model Field, and the schema will use
-the Field's type. 
-
-In Shinobi (and Django 5.0+), you can add `ChoicesMixin` to your Enum and ModelSchema will 
-automatically use it.
 
 ```python
 from django.db import models
@@ -206,4 +207,4 @@ class MySchema(ModelSchema):
 ```
 
 !!! info
-    Note that we are setting `choices` to `NumberEnum`, *not* `NumberEnum.choices`. 
+    Note that `choices` must be set to `NumberEnum`, *not* `NumberEnum.choices`.

--- a/docs/docs/guides/response/django-pydantic.md
+++ b/docs/docs/guides/response/django-pydantic.md
@@ -174,3 +174,36 @@ def modify_data(request, pk: int, payload: PatchDict[GroupSchema]):
 ```
 
 in this example the `payload` argument will be a type of `dict` only fields that were passed in request and validated using `GroupSchema`
+
+### Choices and Enums
+
+!!! info
+    Requires Django 5.0+ and Python 3.11+
+
+By default, ModelSchema, will ignore `choices` on a Model Field, and the schema will use
+the Field's type. 
+
+In Shinobi (and Django 5.0+), you can add `ChoicesMixin` to your Enum and ModelSchema will 
+automatically use it.
+
+```python
+from django.db import models
+from ninja import ModelSchema
+from ninja.enum import ChoicesMixin
+
+class NumberEnum(ChoicesMixin, models.TextChoices):
+    ONE = "ONE", "One"
+    TWO = "TWO", "Two"
+    THREE = "THREE", "Three"
+
+class MyModel(models.Model):
+    number = models.CharField(max_length=10, choices=NumberEnum)
+
+class MySchema(ModelSchema):
+    class Meta:
+        model = MyModel
+        fields = ["number"]
+```
+
+!!! info
+    Note that we are setting `choices` to `NumberEnum`, *not* `NumberEnum.choices`. 

--- a/ninja/enum.py
+++ b/ninja/enum.py
@@ -1,0 +1,34 @@
+from typing import Any, List, Tuple, TypeVar
+
+import django
+
+# Because this isn't supported with Django <5, we need to ignore coverage for
+# unsupported versions.
+
+if django.VERSION[0] < 5:  # pragma: no cover
+
+    class NinjaChoicesType(type): ...
+
+    class ChoicesMixin: ...
+
+else:  # pragma: no cover
+    from django.db.models.enums import ChoicesType
+
+    class NinjaChoicesType(ChoicesType):  # type: ignore[no-redef]
+        @property
+        def choices(self) -> "List[Tuple[Any, str]]":
+            return NinjaChoicesList(super().choices, choices_enum=self)
+
+    class ChoicesMixin(metaclass=NinjaChoicesType):  # type: ignore[no-redef]
+        pass
+
+
+ListMemberType = TypeVar("ListMemberType")
+
+
+class NinjaChoicesList(List[ListMemberType]):
+    def __init__(
+        self, *args: Any, choices_enum: NinjaChoicesType, **kwargs: Any
+    ) -> None:  # pragma: no cover
+        self.enum = choices_enum
+        super().__init__(*args, **kwargs)

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, IPvAnyAddress
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined, core_schema
 
+from ninja.enum import NinjaChoicesList
 from ninja.errors import ConfigError
 from ninja.openapi.schema import OpenAPISchema
 from ninja.types import DictStrAny
@@ -184,6 +185,9 @@ def get_schema_field(
                 default_factory = field.default
             else:
                 default = field.default
+
+        if isinstance(field.choices, NinjaChoicesList):  # pragma: no cover
+            python_type = field.choices.enum
 
     if default_factory:
         default = PydanticUndefined

--- a/tests/test_orm_schemas.py
+++ b/tests/test_orm_schemas.py
@@ -258,7 +258,7 @@ def test_django_31_fields():
     django.VERSION[0] < 5 or version_info < (3, 11),
     reason="Not supported on Django <5 and Python <3.11",
 )
-def test_enum_field():
+def test_choicesmixin_choices_field():
     class TestEnum(ChoicesMixin, TextChoices):
         ONE = "ONE", "One"
         TWO = "TWO", "Two"

--- a/tests/test_orm_schemas.py
+++ b/tests/test_orm_schemas.py
@@ -1,12 +1,16 @@
+from sys import version_info
 from typing import List
 from unittest.mock import Mock
 
+import django
 import pytest
 from django.contrib.postgres import fields as ps_fields
 from django.db import models
 from django.db.models import Manager
+from django.db.models.enums import TextChoices
 from util import pydantic_arbitrary_dict_fix, pydantic_ref_fix
 
+from ninja.enum import ChoicesMixin
 from ninja.errors import ConfigError
 from ninja.orm import create_schema, register_field
 from ninja.orm.shortcuts import L, S
@@ -246,6 +250,46 @@ def test_django_31_fields():
         "id": 1,
         "jsonfield": {"any": "data"},
         "positivebigintegerfield": 1,
+    }
+
+
+@pytest.mark.skipif(
+    django.VERSION[0] < 5 or version_info < (3, 11),
+    reason="Not supported on Django <5 and Python <3.11",
+)
+def test_enum_field():
+    class TestEnum(ChoicesMixin, TextChoices):
+        ONE = "ONE", "One"
+        TWO = "TWO", "Two"
+        THREE = "THREE", "Three"
+
+    class EnumModel(models.Model):
+        number = models.CharField(max_length=10, choices=TestEnum)
+
+        class Meta:
+            app_label = "tests"
+
+    Schema = create_schema(EnumModel)
+
+    assert Schema.json_schema() == {
+        "$defs": {
+            "TestEnum": {
+                "enum": ["ONE", "TWO", "THREE"],
+                "title": "TestEnum",
+                "type": "string",
+            }
+        },
+        "properties": {
+            "id": {"title": "ID", "type": "integer"},
+            "number": {
+                "$ref": "#/$defs/TestEnum",
+                "maxLength": 10,
+                "title": "Number",
+            },
+        },
+        "required": ["id", "number"],
+        "title": "EnumModel",
+        "type": "object",
     }
 
 


### PR DESCRIPTION
This adds support to `ModelSchema` for using a Field's Enum/Choices. This is done with the use of the mixin, `ChoicesMixin`.

```python
from django.db import models
from ninja import ModelSchema
from ninja.enum import ChoicesMixin

class NumberEnum(ChoicesMixin, models.TextChoices):
    ONE = "ONE", "One"
    TWO = "TWO", "Two"
    THREE = "THREE", "Three"

class MyModel(models.Model):
    number = models.CharField(max_length=10, choices=NumberEnum)

class MySchema(ModelSchema):
    class Meta:
        model = MyModel
        fields = ["number"]
```

This is a companion to #16, which provides fallback support if the user didn't use `ChoicesMixin`.

This commit required a ton of coverage ignores `# pragma: no cover` because the coverage job runs _only_ on 3.9. This is only compatible with Django 5 because of the changes made to choices in it, and Python 3.11+ for some other reason.
