### PR TITLE
Improve performance by removing DjangoGetter

### DIFF
--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -22,7 +22,7 @@ from pydantic_core import PydanticUndefined, core_schema
 
 from ninja.errors import ConfigError
 from ninja.openapi.schema import OpenAPISchema
-from ninja.types import DictStrAny
+from ninja.types import DictStrAny, FileFieldType
 
 __all__ = ["create_m2m_link_type", "get_schema_field", "get_related_field_schema"]
 
@@ -65,12 +65,13 @@ TYPES = {
     "DateTimeField": datetime.datetime,
     "DecimalField": Decimal,
     "DurationField": datetime.timedelta,
-    "FileField": str,
+    "FileField": FileFieldType,
     "FilePathField": str,
     "FloatField": float,
     "GenericIPAddressField": IPvAnyAddress,
     "IPAddressField": IPvAnyAddress,
     "IntegerField": int,
+    "ImageField": FileFieldType,
     "JSONField": AnyObject,
     "NullBooleanField": bool,
     "PositiveBigIntegerField": int,

--- a/ninja/types.py
+++ b/ninja/types.py
@@ -1,12 +1,7 @@
-from typing import Any, Callable, Dict, TypeVar, Annotated, TypeAliasType, Type
+from typing import Any, Callable, Dict, TypeVar
 
 __all__ = ["DictStrAny", "TCallable"]
 
-from django.db.models import Manager, QuerySet, FileField
-from django.db.models.fields.files import ImageFieldFile, FieldFile
-from pydantic import BeforeValidator, GetJsonSchemaHandler, GetCoreSchemaHandler
-from pydantic.json_schema import JsonSchemaValue
-from pydantic_core import core_schema
 
 DictStrAny = Dict[str, Any]
 
@@ -19,4 +14,3 @@ TCallable = TypeVar("TCallable", bound=Callable[..., Any])
 
 # Todo: Actually figure out how to type this correctly for Pydantic
 FileFieldType = str
-

--- a/ninja/types.py
+++ b/ninja/types.py
@@ -1,6 +1,12 @@
-from typing import Any, Callable, Dict, TypeVar
+from typing import Any, Callable, Dict, TypeVar, Annotated, TypeAliasType, Type
 
 __all__ = ["DictStrAny", "TCallable"]
+
+from django.db.models import Manager, QuerySet, FileField
+from django.db.models.fields.files import ImageFieldFile, FieldFile
+from pydantic import BeforeValidator, GetJsonSchemaHandler, GetCoreSchemaHandler
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import core_schema
 
 DictStrAny = Dict[str, Any]
 
@@ -10,3 +16,7 @@ TCallable = TypeVar("TCallable", bound=Callable[..., Any])
 # unfortunately this doesn't work yet, see
 # https://github.com/python/mypy/issues/3924
 # Decorator = Callable[[TCallable], TCallable]
+
+# Todo: Actually figure out how to type this correctly for Pydantic
+FileFieldType = str
+


### PR DESCRIPTION
Because Schema uses a `wrap` model validator, during validation all data must be materialized in Python. I believe this was done because that's how Ninja worked with Pydantic v1, and that was fine back then. However, if we can get rid of the wrap validator, then Pydantic v2's Rust core should allow us to validate much, much faster.

I'm exploring options for compatibility and gradual migration, but its likely that removing DjangoGetter will be a breaking change. If that's the case, the plan is to add a setting, something like `NINJA_COMPATIBILITY_MODE`, which will be by default set to False (to try to get new users started without DjangoGetter) but you can set to True if you aren't ready to convert your codebase and still need DjangoGetter.

DjangoGetter provides four different important features. Their solutions have some pros and cons so I'd like to get some feedback on them or how they would affect how you use Shinobi.

1. Turn Managers into QuerySets

Given a Author model that was foreign keyed, one-to-many, to a Book model, you might do something like this in your schema.

```python
class BookSchema(ModelSchema):
    class Meta:
        model = Book
        fields = ["name"]

class Author(ModelSchema):
    books: List[BookSchema]

    class Meta:
        model = Author
        fields = ["name"]
```

Which will return JSON like 

```
{
  "name": "J. R. R. Tolkein",
  "books": [
    "The Hobbit",
    "The Fellowship of the Ring",
    ...
  ]
}
```

However, to actually get those books, you normally need to call `.books.all()` on the Author object. Pydantic doesn't know how to do this, and will attempt to list results out of the RelatedManager object, `.books`, which results in an error.

One quick and dirty solution is to monkey patch the RelatedManager to behave like a QuerySet and resolve and cache results when prompted by Pydantic. This solution could have odd side effects, so I decided against it.

As it does now, `Schema` looks at all of the field types attached to it and checks if any are `Collection` type (lists, sets, etc.). If there are, it attaches a before field validator, `_manager_to_queryset`, which checks if the incoming value is a Manager and returns a QuerySet if it is. This does about the same thing that DjangoGetter does, but it will check on far fewer fields and carries no extra baggage.

2. Validating FileFields

Previously, DjangoGetter would turn all FileFields into their file's URL, or None if they had nothing. This has the unfortunate downside of making other ways of presenting files impossible ([Ninja 1410](/vitalik/django-ninja/issues/1410)), so this PR might also be able to help solve this problem,

FileFields now require the use of the `FileFieldType`, which is a type annotation that contains a before field validator which checks if the incoming values is a FieldFile and returns its URL or None, similar to DjangoGetter. This opens the door to alternative type annotations for FileFields that could have validators that do different things. The default type for FileFields can also be overridden with `register_custom_field`. 

At least, this is the plan. I tried this and then when you would do something like 

```
class MySchema:
    file: Optional[FileFieldType]
```

Pydantic would ignore the `Optional` type around it and just consider `file` to be a non-nullable string. If anyone with better Pydantic-fu could explain how to do this, I could use some help!

3. Resolvers are combined into a before model validator

Resolvers are a helper tool for Schema fields that may not have an exact name match on the incoming data.

```
class MySchema:
    name: str
    
    @staticmethod
    def resolve_name(obj):
        return obj.first_name + obj.last_name
```

DjangoGetter was in charge of checking and executing them. Instead, we can attach a before model validator that loops through them and executes them, then merges the results with the incoming values.

The tricky part with this is that the incoming values could be of several different types, and any existing Resolvers are expecting to be presented a DjangoGetter instance. I'm still wrapping the incoming object in DjangoGetter to solve this for the moment, but the plan is to write a lighter weight alternative to DjangoGetter and swap to that when not in compatibility mode.

4. Removing(?) Django template syntax-like alias pathing

Shinobi currently supports aliases like this

```
class AliasSchema(Schema):
    value: int = Field(..., alias="m.call.dict.1")
```

which will try to chain attribute accesses, function calls, item accesses, whatever works to navigate from the original Python object.

I want to instead encourage users to use the built-in Pydantic feature for this, which executes in Rust. It looks like this

```
class AliasSchema(Schema):
    value: int = Field(..., validation_alias=AliasPath("m", "call", "dict", 1))
```

However, unlike DjangoGetter, AliasSchema cannot call any functions. I'd like to think this is OK, since it was only able to call functions with no arguments anyways (and there's always `@property`), but if you rely on this, let me know.

For the sake of compatibility, we could detect a user is using this alias pathing and attach a before model validator that solves it using DjangoGetter's logic.

---

What kind of performance improvement are we talking with this? I've done some profiling with my job's Django application and I would lowball it at minimum 4x, give or take on the schema. I think it will definitely be worth the effort.