### PR TITLE
Fix NINJA_COMPATIBILITY default value typo in docs

### DIFF
--- a/docs/docs/differences.md
+++ b/docs/docs/differences.md
@@ -40,7 +40,7 @@ class MySchema(Schema):
     ...
 ```
 
-In 1.5.0, the default value for `NINJA_COMPATIBILITY` will be set to `True`, making the performance improvements 
+In 1.5.0, the default value for `NINJA_COMPATIBILITY` will be set to `False`, making the performance improvements 
 **opt-out**. The compatibility behavior will be removed in 1.6.0.
 
 ### Improved Choices Enum support


### PR DESCRIPTION
Docs currently states the NINJA_COMPATIBILITY will be set to `True` in 1.5.0.  Given the current default is `True`, this fix corrects the typo to say it'll be changed to `False`.