### PR TITLE
Update typing for 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: v1.7.1
     hooks:
       - id: mypy
-        additional_dependencies: ["django-stubs", "pydantic~=2.12"]
+        additional_dependencies: ["django-stubs==5.1.3", "pydantic~=2.12", "django~=4.2"]
         exclude: (tests|docs)/
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.5.7

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.8
+python_version = 3.12
 
 show_column_numbers = True
 show_error_codes = True

--- a/ninja/constants.py
+++ b/ninja/constants.py
@@ -10,7 +10,7 @@ class NOT_SET_TYPE:
     def __copy__(self) -> Any:
         return NOT_SET
 
-    def __deepcopy__(self, memodict: Optional[Dict] = None) -> Any:
+    def __deepcopy__(self, memodict: Optional[Dict[Any, Any]] = None) -> Any:
         return NOT_SET
 
 


### PR DESCRIPTION
Upstream still uses 3.9 for the mypy checks so it's now forcing us to use pretty out of date packages to maintain parity